### PR TITLE
do not uselesly create sessions

### DIFF
--- a/src/main/java/org/esupportail/tomcat/ChangeSessionIdValve.java
+++ b/src/main/java/org/esupportail/tomcat/ChangeSessionIdValve.java
@@ -18,11 +18,10 @@ public final class ChangeSessionIdValve extends ValveBase {
 
     public void invoke(Request request, Response response) throws
 	IOException, ServletException {
-	Session session = request.getSessionInternal(true);
 	String requestURI = request.getDecodedRequestURI();
 
-	if (session != null && loginPath != null &&
-	    requestURI.equals(loginPath)) {
+	if (loginPath != null && requestURI.equals(loginPath)) {
+	    Session session = request.getSessionInternal(true);
 	    Manager manager = request.getContext().getManager();
 	    manager.changeSessionId(session);
 	    request.changeSessionId(session.getId());


### PR DESCRIPTION
Tested on our uportal3.2 / tomcat6

NB : since 09 feb 2015 we do not use the valve anymore since we removed emptySessionPath/sessionCookiePath from tomcat conf. This is possible since we have uportal on "/" and not "/uPortal". And everything works nicely without emptySessionPath!
